### PR TITLE
Handle empty hints

### DIFF
--- a/src/Controllers/QuizController.js
+++ b/src/Controllers/QuizController.js
@@ -287,20 +287,23 @@ class QuizController {
       );
     };
 
+    function getHintMessage(message) {
+      return `<strong>${message}</strong>`
+    }
+    
+    function getHintIFrame(url) {
+      return`<iframe style="border:none;" height="600" width="9" sandbox"allow-forms allow-scripts" src="${url}"></iframe>`;
+    }
+
     $rootScope.$on('SHOWHINT', function (event, args) {
+      let hintMessage = args.hint || "No hint given!";
+      let hintWebsite = args.hintUrl || "https://www.google.com";
+      let htmlContent = `${getHintMessage(hintMessage)}<hr/><br/>${getHintIFrame(hintWebsite)}`;
       $mdDialog
         .show($mdDialog
           .alert()
           .title('More info goes here.')
-          .htmlContent(
-            $sce.trustAsHtml(
-              '<strong>'
-              + args.hint
-              + '</strong><hr><br><iframe style=\'border:none;\' height=\'600\' width=\'9\' sandbox=\'allow-forms allow-scripts\' src=\''
-              + (args.hintUrl ? args.hintUrl : 'https://google.com')
-              + '\'></iframe>'
-            )
-          )
+          .htmlContent($sce.trustAsHtml(htmlContent))
           .ariaLabel('More info')
           .ok('Got it')
           .targetEvent(event)

--- a/src/Factory/QuizFactory.js
+++ b/src/Factory/QuizFactory.js
@@ -69,16 +69,12 @@ class QuizFactory {
             // Set id if null;
             value.id = value.id || (key + 1);
             if (
-              (self.config.DEBUGMODE && value.hint == '')
-              || (!self.config.DEBUGMODE && value.hint != '')
-            ) {
-              if (
                 !self.getConfig('SKIPCORRECT')
                 || answeredIds.indexOf(value.id) == -1
               ) {
                 self.questions.push(value);
               }
-            }
+
           });
           self.header = json.data.header;
           $rootScope.$broadcast('START');


### PR DESCRIPTION
This is work towards #13 

1. When hint and hintURL are empty
<img width="964" alt="When hint and hintURL are empty" src="https://user-images.githubusercontent.com/6629172/66268234-07aca880-e859-11e9-8248-2632c51a911b.png">

2. When hint is empty but hintURL is given
<img width="1184" alt="When hint is empty but hintURL is given" src="https://user-images.githubusercontent.com/6629172/66268267-54907f00-e859-11e9-90cb-f390837edcf0.png">

The other two cases work as they currently do.

Thoughts @xeurun ?